### PR TITLE
検索画面のハイライトを追加

### DIFF
--- a/App/Extensions/AttributedString+Extensions.swift
+++ b/App/Extensions/AttributedString+Extensions.swift
@@ -1,0 +1,13 @@
+import Foundation
+
+extension AttributedString {
+    func ranges<T: StringProtocol>(of stringToFind: T) -> [Range<AttributedString.Index>] {
+        var ranges: [Range<AttributedString.Index>] = []
+        var substring = self[self.startIndex ..< self.endIndex]
+        while let range = substring.range(of: stringToFind) {
+            ranges.append(range)
+            substring = self[range.upperBound...]
+        }
+        return ranges
+    }
+}

--- a/App/Screens/Session/Views/SessionRow.swift
+++ b/App/Screens/Session/Views/SessionRow.swift
@@ -31,7 +31,7 @@ struct SessionRow: View {
 }
 
 // MARK: - Track Tag
-private struct SessionRowTrackTag: View {
+struct SessionRowTrackTag: View {
     
     let name: String
     
@@ -41,7 +41,7 @@ private struct SessionRowTrackTag: View {
 }
 
 // MARK: - Sponsor Tag
-private struct SessionRowSponsorTag: View {
+struct SessionRowSponsorTag: View {
     
     let isSponsor: Bool
     
@@ -53,7 +53,7 @@ private struct SessionRowSponsorTag: View {
 }
 
 // MARK: - LT Tag
-private struct SessionRowLtTag: View {
+struct SessionRowLtTag: View {
     
     let isLT: Bool
     
@@ -65,7 +65,7 @@ private struct SessionRowLtTag: View {
 }
 
 // MARK: - User Tag
-private struct SessionRowUserTag: View {
+struct SessionRowUserTag: View {
     
     let user: SessionUser?
     

--- a/App/Screens/SessionList/SessionListView.swift
+++ b/App/Screens/SessionList/SessionListView.swift
@@ -45,7 +45,7 @@ private extension SessionListView {
         ScrollView {
             LazyVStack(spacing: 8) {
                 ForEach(viewModel.binding.models, id: \.self) { model in
-                    SessionRow(model: model) {
+                    SessionListRow(model: model, highlightText: viewModel.binding.searchText.value) {
                         viewModel.input.didTapSession.send(model)
                     }
                 }

--- a/App/Screens/SessionList/Views/SessionListRow.swift
+++ b/App/Screens/SessionList/Views/SessionListRow.swift
@@ -1,0 +1,105 @@
+import SwiftUI
+
+// MARK: - Row
+struct SessionListRow: View {
+    let model: SessionModel
+    let highlightText: String
+    let didTap: () -> Void
+    
+    var body: some View {
+        Button(action: didTap) {
+            HStack {
+                VStack(alignment: .leading, spacing: 4) {
+                    HStack(spacing: 4) {
+                        SessionRowTrackTag(name: model.track.name)
+                        SessionRowSponsorTag(isSponsor: model.isSponsor)
+                        SessionRowLtTag(isLT: model.isLT)
+                        SessionRowUserTag(user: model.user)
+                    }
+                    .padding(.bottom, 4)
+                    
+                    SessionListRowTitleLabel(title: model.title, highlightText: highlightText)
+                    SessionListRowBodyLabel(bodyText: model.description!, highlightText: highlightText)
+                }
+                .padding(.all, 2)
+                
+                Spacer()
+            }
+        }
+        .padding(.all, 8)
+        .background(Color.secondarySystemBackground)
+        .cornerRadius(12)
+    }
+}
+
+// MARK: - Title Label
+private struct SessionListRowTitleLabel: View {
+    
+    let title: String
+    let highlightText: String
+    
+    var attributedText: AttributedString {
+        var attributedText = AttributedString(title)
+        if let range = attributedText.range(of: highlightText) {
+            attributedText[range].foregroundColor = .blue
+        }
+        return attributedText
+    }
+    
+    var body: some View {
+        Text(attributedText)
+            .font(.headline)
+            .foregroundColor(.primary)
+            .multilineTextAlignment(.leading)
+    }
+}
+
+// MARK: - Body Label
+private struct SessionListRowBodyLabel: View {
+    
+    let bodyText: String
+    let highlightText: String
+    
+    var attributedText: AttributedString? {
+        let highlightTextColor: AttributeScopes.SwiftUIAttributes.ForegroundColorAttribute.Value = .blue
+        
+        var attributedLines: [AttributedString] = []
+        bodyText.enumerateLines { line, stop in
+            var attributedLine = AttributedString(line)
+            let ranges = attributedLine.ranges(of: highlightText)
+            for range in ranges {
+                attributedLine[range].foregroundColor = highlightTextColor
+            }
+            attributedLines.append(attributedLine)
+        }
+        
+        let firstAttributedIndex = attributedLines.firstIndex { attributedString in
+            attributedString.runs.contains { run in
+                run.foregroundColor == highlightTextColor
+            }
+        }
+        /// ハイライトテキストが存在しなければnilを返す
+        guard let firstAttributedIndex = firstAttributedIndex else { return nil }
+        
+        /// 最初にハイライトする文字の前後1行づつを取り出す
+        let lowerIndex = max(firstAttributedIndex - 1, attributedLines.startIndex)
+        let upperIndex = min(firstAttributedIndex + 1, attributedLines.endIndex)
+        let displayLines = attributedLines[lowerIndex..<upperIndex]
+        
+        var attributedText = AttributedString()
+        for attributedLine in displayLines {
+            attributedText.append(attributedLine)
+        }
+        return attributedText
+    }
+    
+    var body: some View {
+        if let attributedText = attributedText {
+            Text(attributedText)
+                .font(.body)
+                .foregroundColor(.primary)
+                .lineLimit(3)
+                .multilineTextAlignment(.leading)
+        }
+    }
+}

--- a/App/Screens/SessionList/Views/SessionListRow.swift
+++ b/App/Screens/SessionList/Views/SessionListRow.swift
@@ -40,7 +40,8 @@ private struct SessionListRowTitleLabel: View {
     
     var attributedText: AttributedString {
         var attributedText = AttributedString(title)
-        if let range = attributedText.range(of: highlightText) {
+        var lowercasedAttributedText = AttributedString(title.lowercased())
+        if let range = lowercasedAttributedText.range(of: highlightText.lowercased()) {
             attributedText[range].foregroundColor = .blue
         }
         return attributedText
@@ -66,7 +67,8 @@ private struct SessionListRowBodyLabel: View {
         var attributedLines: [AttributedString] = []
         bodyText.enumerateLines { line, stop in
             var attributedLine = AttributedString(line)
-            let ranges = attributedLine.ranges(of: highlightText)
+            var lowercasedAttributedLine = AttributedString(line.lowercased())
+            let ranges = lowercasedAttributedLine.ranges(of: highlightText.lowercased())
             for range in ranges {
                 attributedLine[range].foregroundColor = highlightTextColor
             }
@@ -98,7 +100,6 @@ private struct SessionListRowBodyLabel: View {
             Text(attributedText)
                 .font(.body)
                 .foregroundColor(.primary)
-                .lineLimit(3)
                 .multilineTextAlignment(.leading)
         }
     }


### PR DESCRIPTION
検索画面でハイライト出来るようにしました。

![CleanShot 2022-08-18 at 03 17 13](https://user-images.githubusercontent.com/2066707/185213300-a8735879-127f-40c7-a706-d8aac1b212d0.gif)

- タイトルを全文表示
- タイトルに検索文字列が含まれる場合はハイライト
- 本文に検索文字列が含まれる場合に本文を表示
- 本文に検索文字列が含まれる場合にハイライト
- 本文の検索文字列が登場する最初の行の前後１行を表示
- 検索文字列はタイトルと本文からlowercaseで探す