### PR TITLE
検索画面のロジックコードをモデルに移動

### DIFF
--- a/App/Screens/Session/Models/SessionModel.swift
+++ b/App/Screens/Session/Models/SessionModel.swift
@@ -43,11 +43,15 @@ extension SessionModel {
 // MARK: - SessionListRowTitleLabel & SessionListRowBodyLabel
 extension SessionModel {
     
+    private var highlightTextColor: AttributeScopes.SwiftUIAttributes.ForegroundColorAttribute.Value {
+        .blue
+    }
+    
     func attributedText(with text: String,  and highlightText: String) -> AttributedString {
         var attributedText = AttributedString(text)
         let lowercasedAttributedText = AttributedString(text.lowercased())
         if let range = lowercasedAttributedText.range(of: highlightText.lowercased()) {
-            attributedText[range].foregroundColor = .blue
+            attributedText[range].foregroundColor = highlightTextColor
         }
         return attributedText
     }
@@ -66,9 +70,7 @@ extension SessionModel {
         }
         
         let firstAttributedIndex = attributedLines.firstIndex { attributedString in
-            attributedString.runs.contains { run in
-                run.foregroundColor == .blue
-            }
+            attributedString.runs.contains { $0.foregroundColor == highlightTextColor }
         }
         /// ハイライトテキストが存在しなければnilを返す
         guard let firstAttributedIndex = firstAttributedIndex else { return nil }

--- a/App/Screens/Session/Models/SessionModel.swift
+++ b/App/Screens/Session/Models/SessionModel.swift
@@ -40,6 +40,52 @@ extension SessionModel {
     }
 }
 
+// MARK: - SessionListRowTitleLabel & SessionListRowBodyLabel
+extension SessionModel {
+    
+    func attributedText(with text: String,  and highlightText: String) -> AttributedString {
+        var attributedText = AttributedString(text)
+        let lowercasedAttributedText = AttributedString(text.lowercased())
+        if let range = lowercasedAttributedText.range(of: highlightText.lowercased()) {
+            attributedText[range].foregroundColor = .blue
+        }
+        return attributedText
+    }
+    
+    func attributedTitleText(with highlightText: String) -> AttributedString {
+        attributedText(with: title, and: highlightText)
+    }
+    
+    func attributedBodyText(with highlightText: String) -> AttributedString? {
+        guard let bodyText = description else { return nil }
+
+        var attributedLines: [AttributedString] = []
+        bodyText.enumerateLines { line, _ in
+            let text = attributedText(with: line, and: highlightText)
+            attributedLines.append(text)
+        }
+        
+        let firstAttributedIndex = attributedLines.firstIndex { attributedString in
+            attributedString.runs.contains { run in
+                run.foregroundColor == .blue
+            }
+        }
+        /// ハイライトテキストが存在しなければnilを返す
+        guard let firstAttributedIndex = firstAttributedIndex else { return nil }
+        
+        /// 最初にハイライトする文字の前後1行づつを取り出す
+        let lowerIndex = max(firstAttributedIndex - 1, attributedLines.startIndex)
+        let upperIndex = min(firstAttributedIndex + 1, attributedLines.endIndex)
+        let displayLines = attributedLines[lowerIndex..<upperIndex]
+        
+        var attributedString = AttributedString()
+        for attributedLine in displayLines {
+            attributedString.append(attributedLine)
+        }
+        return attributedString
+    }
+}
+
 // MARK: - Hashable
 extension SessionModel: Hashable {
     

--- a/App/Screens/SessionList/SessionListView.swift
+++ b/App/Screens/SessionList/SessionListView.swift
@@ -10,12 +10,12 @@ struct SessionListView: View {
             sessionListWrapper
                 .toolbar { closeToolbarContent }
                 .frame(maxWidth: .infinity)
-                .navigationBarTitle(Text(""), displayMode: .inline)
+                .navigationBarTitle("Search", displayMode: .inline)
         }
         .searchable(
             text: $viewModel.binding.searchText.value, 
             placement: .navigationBarDrawer(displayMode: .always),
-            prompt: Text("SessionList_Search_Placeholder")
+            prompt: Text("タイトル、説明、登壇者")
         )
         .sheet(
             isPresented: $viewModel.binding.isShownModal,
@@ -45,9 +45,11 @@ private extension SessionListView {
         ScrollView {
             LazyVStack(spacing: 8) {
                 ForEach(viewModel.binding.models, id: \.self) { model in
-                    SessionListRow(model: model, highlightText: viewModel.binding.searchText.value) {
-                        viewModel.input.didTapSession.send(model)
-                    }
+                    SessionListRow(
+                        model: model,
+                        searchText: $viewModel.binding.searchText.value,
+                        didTap: { viewModel.input.didTapSession.send(model) }
+                    )
                 }
             }
             .padding(.all, 16)

--- a/App/Screens/SessionList/Views/SessionListRow.swift
+++ b/App/Screens/SessionList/Views/SessionListRow.swift
@@ -18,8 +18,8 @@ struct SessionListRow: View {
                     }
                     .padding(.bottom, 4)
                     
-                    SessionListRowTitleLabel(model: model, searchText: $searchText)
-                    SessionListRowBodyLabel(model: model, searchText: $searchText)
+                    SessionListRowTitleLabel(text: model.attributedTitleText(with: searchText))
+                    SessionListRowBodyLabel(text: model.attributedBodyText(with: searchText))
                 }
                 .padding(.all, 2)
                 
@@ -34,11 +34,10 @@ struct SessionListRow: View {
 
 // MARK: - Title Label
 private struct SessionListRowTitleLabel: View {
-    let model: SessionModel
-    @Binding var searchText: String
+    let text: AttributedString
 
     var body: some View {
-        Text(model.attributedTitleText(with: searchText))
+        Text(text)
             .font(.headline)
             .foregroundColor(.primary)
             .multilineTextAlignment(.leading)
@@ -47,11 +46,10 @@ private struct SessionListRowTitleLabel: View {
 
 // MARK: - Body Label
 private struct SessionListRowBodyLabel: View {
-    let model: SessionModel
-    @Binding var searchText: String
+    let text: AttributedString?
     
     var body: some View {
-        if let attributedText = model.attributedBodyText(with: searchText) {
+        if let attributedText = text {
             Text(attributedText)
                 .font(.body)
                 .foregroundColor(.primary)

--- a/App/Screens/SessionList/Views/SessionListRow.swift
+++ b/App/Screens/SessionList/Views/SessionListRow.swift
@@ -3,7 +3,7 @@ import SwiftUI
 // MARK: - Row
 struct SessionListRow: View {
     let model: SessionModel
-    let highlightText: String
+    @Binding var searchText: String
     let didTap: () -> Void
     
     var body: some View {
@@ -18,8 +18,8 @@ struct SessionListRow: View {
                     }
                     .padding(.bottom, 4)
                     
-                    SessionListRowTitleLabel(title: model.title, highlightText: highlightText)
-                    SessionListRowBodyLabel(bodyText: model.description!, highlightText: highlightText)
+                    SessionListRowTitleLabel(model: model, searchText: $searchText)
+                    SessionListRowBodyLabel(model: model, searchText: $searchText)
                 }
                 .padding(.all, 2)
                 
@@ -34,21 +34,11 @@ struct SessionListRow: View {
 
 // MARK: - Title Label
 private struct SessionListRowTitleLabel: View {
-    
-    let title: String
-    let highlightText: String
-    
-    var attributedText: AttributedString {
-        var attributedText = AttributedString(title)
-        var lowercasedAttributedText = AttributedString(title.lowercased())
-        if let range = lowercasedAttributedText.range(of: highlightText.lowercased()) {
-            attributedText[range].foregroundColor = .blue
-        }
-        return attributedText
-    }
-    
+    let model: SessionModel
+    @Binding var searchText: String
+
     var body: some View {
-        Text(attributedText)
+        Text(model.attributedTitleText(with: searchText))
             .font(.headline)
             .foregroundColor(.primary)
             .multilineTextAlignment(.leading)
@@ -57,46 +47,11 @@ private struct SessionListRowTitleLabel: View {
 
 // MARK: - Body Label
 private struct SessionListRowBodyLabel: View {
-    
-    let bodyText: String
-    let highlightText: String
-    
-    var attributedText: AttributedString? {
-        let highlightTextColor: AttributeScopes.SwiftUIAttributes.ForegroundColorAttribute.Value = .blue
-        
-        var attributedLines: [AttributedString] = []
-        bodyText.enumerateLines { line, stop in
-            var attributedLine = AttributedString(line)
-            var lowercasedAttributedLine = AttributedString(line.lowercased())
-            let ranges = lowercasedAttributedLine.ranges(of: highlightText.lowercased())
-            for range in ranges {
-                attributedLine[range].foregroundColor = highlightTextColor
-            }
-            attributedLines.append(attributedLine)
-        }
-        
-        let firstAttributedIndex = attributedLines.firstIndex { attributedString in
-            attributedString.runs.contains { run in
-                run.foregroundColor == highlightTextColor
-            }
-        }
-        /// ハイライトテキストが存在しなければnilを返す
-        guard let firstAttributedIndex = firstAttributedIndex else { return nil }
-        
-        /// 最初にハイライトする文字の前後1行づつを取り出す
-        let lowerIndex = max(firstAttributedIndex - 1, attributedLines.startIndex)
-        let upperIndex = min(firstAttributedIndex + 1, attributedLines.endIndex)
-        let displayLines = attributedLines[lowerIndex..<upperIndex]
-        
-        var attributedText = AttributedString()
-        for attributedLine in displayLines {
-            attributedText.append(attributedLine)
-        }
-        return attributedText
-    }
+    let model: SessionModel
+    @Binding var searchText: String
     
     var body: some View {
-        if let attributedText = attributedText {
+        if let attributedText = model.attributedBodyText(with: searchText) {
             Text(attributedText)
                 .font(.body)
                 .foregroundColor(.primary)

--- a/AppTest/Screens/SessionList/Models/SessionModelTest+SessionList.swift
+++ b/AppTest/Screens/SessionList/Models/SessionModelTest+SessionList.swift
@@ -43,12 +43,14 @@ extension SessionModelTest {
             
             // highlight text
             let result1 = model.attributedBodyText(with: "test")
-            AssertNotNil(result1)
-            AssertFalse(result1!.ranges(of: "test").isEmpty)
+            let value = try AssertUnwrap(result1)
+            AssertFalse(value.ranges(of: "test").isEmpty)
             
             // non highlight text
             let result2 = model.attributedBodyText(with: "xxxx")
             AssertNil(result2)
+        } catch {
+            assertionFailure("fail to unwrap")
         }
     }
 }

--- a/AppTest/Screens/SessionList/Models/SessionModelTest+SessionList.swift
+++ b/AppTest/Screens/SessionList/Models/SessionModelTest+SessionList.swift
@@ -1,0 +1,56 @@
+#if TESTING_ENABLED
+
+import PlaygroundTester
+
+// MARK: - Test
+extension SessionModelTest {
+    
+    func testAttributedText() {
+        let model = SessionModel(track: .a, title: "")
+        
+        // contains text
+        let result1 = model.attributedText(with: "test_text", and: "test")
+        AssertFalse(result1.ranges(of: "test").isEmpty)
+        
+        // non contains text
+        let result2 = model.attributedText(with: "test_text", and: "xxxx")
+        Assert(result2.ranges(of: "yyyy").isEmpty)
+    }
+    
+    func testAttributedTitleText() {
+        let model = SessionModel(track: .a, title: "test_title")
+        
+        // contains text
+        let result1 = model.attributedTitleText(with: "test")
+        AssertFalse(result1.ranges(of: "test").isEmpty)
+        
+        // non contains text
+        let result2 = model.attributedTitleText(with: "xxxx")
+        Assert(result2.ranges(of: "yyyy").isEmpty)
+    }
+    
+    func testAttributedBodyText() {
+        // description is nil
+        do {
+            let model = SessionModel(track: .a, title: "", description: nil)
+            let result1 = model.attributedBodyText(with: "test")
+            AssertNil(result1)
+        }
+        
+        // description is not nil
+        do {
+            let model = SessionModel(track: .a, title: "", description: "test_description")
+            
+            // highlight text
+            let result1 = model.attributedBodyText(with: "test")
+            AssertNotNil(result1)
+            AssertFalse(result1!.ranges(of: "test").isEmpty)
+            
+            // non highlight text
+            let result2 = model.attributedBodyText(with: "xxxx")
+            AssertNil(result2)
+        }
+    }
+}
+
+#endif

--- a/AppTest/Screens/SessionList/Models/SessionModelTest+SessionList.swift
+++ b/AppTest/Screens/SessionList/Models/SessionModelTest+SessionList.swift
@@ -5,16 +5,45 @@ import PlaygroundTester
 // MARK: - Test
 extension SessionModelTest {
     
+    /*
+     共通化しているので、大小文字のテストは共通関数のみで実施
+     */
     func testAttributedText() {
         let model = SessionModel(track: .a, title: "")
         
         // contains text
-        let result1 = model.attributedText(with: "test_text", and: "test")
-        AssertFalse(result1.ranges(of: "test").isEmpty)
+        do {
+            // text: lower, highlightText: lower
+            do {
+                let result = model.attributedText(with: "test_text", and: "test")
+                AssertFalse(result.ranges(of: "test").isEmpty)
+                Assert(result.ranges(of: "TEST").isEmpty)
+            }
+            // text: lower, highlightText: upper
+            do {
+                let result = model.attributedText(with: "test_text", and: "TEST")
+                AssertFalse(result.ranges(of: "test").isEmpty)
+                Assert(result.ranges(of: "TEST").isEmpty)
+            }
+            // text: upper, highlightText: lower
+            do {
+                let result = model.attributedText(with: "TEST_TEXT", and: "test")
+                Assert(result.ranges(of: "test").isEmpty)
+                AssertFalse(result.ranges(of: "TEST").isEmpty)
+            }
+            // text: upper, highlightText: upper
+            do {
+                let result = model.attributedText(with: "TEST_TEXT", and: "TEST")
+                Assert(result.ranges(of: "test").isEmpty)
+                AssertFalse(result.ranges(of: "TEST").isEmpty)
+            }
+        }
         
         // non contains text
-        let result2 = model.attributedText(with: "test_text", and: "xxxx")
-        Assert(result2.ranges(of: "yyyy").isEmpty)
+        do {
+            let result = model.attributedText(with: "test_text", and: "xxxx")
+            Assert(result.ranges(of: "xxxx").isEmpty)
+        }
     }
     
     func testAttributedTitleText() {


### PR DESCRIPTION
- ロジックをモデルに移動
- 子ViewではBindingで受け取るように修正
- テストコードの追加